### PR TITLE
Modified CSP header definitions to permit objects served from same lo…

### DIFF
--- a/simplerisk/account/profile.php
+++ b/simplerisk/account/profile.php
@@ -21,7 +21,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/admin/about.php
+++ b/simplerisk/admin/about.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/admin/active_assessments.php
+++ b/simplerisk/admin/active_assessments.php
@@ -28,7 +28,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/admin/add_remove_values.php
+++ b/simplerisk/admin/add_remove_values.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/admin/announcements.php
+++ b/simplerisk/admin/announcements.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/admin/api.php
+++ b/simplerisk/admin/api.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/admin/assessments.php
+++ b/simplerisk/admin/assessments.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/admin/assetvaluation.php
+++ b/simplerisk/admin/assetvaluation.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/admin/audit_trail.php
+++ b/simplerisk/admin/audit_trail.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/admin/authentication.php
+++ b/simplerisk/admin/authentication.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/admin/custom_names.php
+++ b/simplerisk/admin/custom_names.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/admin/delete_risks.php
+++ b/simplerisk/admin/delete_risks.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/admin/encryption.php
+++ b/simplerisk/admin/encryption.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/admin/extras.php
+++ b/simplerisk/admin/extras.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/admin/importexport.php
+++ b/simplerisk/admin/importexport.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/admin/index.php
+++ b/simplerisk/admin/index.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/admin/mail_settings.php
+++ b/simplerisk/admin/mail_settings.php
@@ -21,7 +21,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/admin/notification.php
+++ b/simplerisk/admin/notification.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/admin/register.php
+++ b/simplerisk/admin/register.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/admin/review_settings.php
+++ b/simplerisk/admin/review_settings.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/admin/separation.php
+++ b/simplerisk/admin/separation.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/admin/upgrade.php
+++ b/simplerisk/admin/upgrade.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Start the session

--- a/simplerisk/admin/uploads.php
+++ b/simplerisk/admin/uploads.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/admin/user_management.php
+++ b/simplerisk/admin/user_management.php
@@ -21,7 +21,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/admin/view_user_details.php
+++ b/simplerisk/admin/view_user_details.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/assessments/assessment.php
+++ b/simplerisk/assessments/assessment.php
@@ -21,7 +21,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Include the language file

--- a/simplerisk/assessments/index.php
+++ b/simplerisk/assessments/index.php
@@ -22,7 +22,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/assessments/risks.php
+++ b/simplerisk/assessments/risks.php
@@ -22,7 +22,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/assets/adddeleteassets.php
+++ b/simplerisk/assets/adddeleteassets.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/assets/edit.php
+++ b/simplerisk/assets/edit.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/assets/index.php
+++ b/simplerisk/assets/index.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/index.php
+++ b/simplerisk/index.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
 	// Session handler is database

--- a/simplerisk/logout.php
+++ b/simplerisk/logout.php
@@ -19,7 +19,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
 	// Session handler is database

--- a/simplerisk/management/close.php
+++ b/simplerisk/management/close.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/management/comment.php
+++ b/simplerisk/management/comment.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/management/cvss_rating.php
+++ b/simplerisk/management/cvss_rating.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/management/download.php
+++ b/simplerisk/management/download.php
@@ -15,7 +15,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/management/dread_rating.php
+++ b/simplerisk/management/dread_rating.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/management/index.php
+++ b/simplerisk/management/index.php
@@ -21,7 +21,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/management/management_review.php
+++ b/simplerisk/management/management_review.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/management/mgmt_review.php
+++ b/simplerisk/management/mgmt_review.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/management/mitigate.php
+++ b/simplerisk/management/mitigate.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/management/owasp_rating.php
+++ b/simplerisk/management/owasp_rating.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/management/plan_mitigations.php
+++ b/simplerisk/management/plan_mitigations.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/management/print_view.php
+++ b/simplerisk/management/print_view.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/management/prioritize_planning.php
+++ b/simplerisk/management/prioritize_planning.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/management/reopen.php
+++ b/simplerisk/management/reopen.php
@@ -19,7 +19,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/management/review_risks.php
+++ b/simplerisk/management/review_risks.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/management/reviews.php
+++ b/simplerisk/management/reviews.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/management/status.php
+++ b/simplerisk/management/status.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/management/view.php
+++ b/simplerisk/management/view.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/reports/closed.php
+++ b/simplerisk/reports/closed.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/reports/closed_by_date.php
+++ b/simplerisk/reports/closed_by_date.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/reports/dashboard.php
+++ b/simplerisk/reports/dashboard.php
@@ -21,7 +21,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/reports/dynamic_risk_report.php
+++ b/simplerisk/reports/dynamic_risk_report.php
@@ -21,7 +21,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/reports/high.php
+++ b/simplerisk/reports/high.php
@@ -21,7 +21,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/reports/index.php
+++ b/simplerisk/reports/index.php
@@ -21,7 +21,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/reports/mgmt_reviews_by_date.php
+++ b/simplerisk/reports/mgmt_reviews_by_date.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/reports/mitigations_by_date.php
+++ b/simplerisk/reports/mitigations_by_date.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/reports/my_open.php
+++ b/simplerisk/reports/my_open.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/reports/next_review.php
+++ b/simplerisk/reports/next_review.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/reports/open.php
+++ b/simplerisk/reports/open.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/reports/production_issues.php
+++ b/simplerisk/reports/production_issues.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/reports/projects.php
+++ b/simplerisk/reports/projects.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/reports/projects_and_risks.php
+++ b/simplerisk/reports/projects_and_risks.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/reports/review_needed.php
+++ b/simplerisk/reports/review_needed.php
@@ -21,7 +21,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/reports/risk_scoring.php
+++ b/simplerisk/reports/risk_scoring.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/reports/riskadvice.php
+++ b/simplerisk/reports/riskadvice.php
@@ -22,7 +22,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/reports/risks_and_assets.php
+++ b/simplerisk/reports/risks_and_assets.php
@@ -21,7 +21,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/reports/submitted_by_date.php
+++ b/simplerisk/reports/submitted_by_date.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/reports/teams.php
+++ b/simplerisk/reports/teams.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/reports/technologies.php
+++ b/simplerisk/reports/technologies.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/reports/trend.php
+++ b/simplerisk/reports/trend.php
@@ -21,7 +21,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database

--- a/simplerisk/reset.php
+++ b/simplerisk/reset.php
@@ -20,7 +20,7 @@
         if (CSP_ENABLED == "true")
         {
                 // Add the Content-Security-Policy header
-                header("Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'");
+                header("Content-Security-Policy: default-src 'self' 'unsafe-inline';");
         }
 
         // Session handler is database


### PR DESCRIPTION
I found that the CSP header definitions broke some of the already included scripts and styles that were on the same  location,port,protocol as site, so I included "self" as the default-src which lets those local scripts and styles be loaded. Keeping 'unsafe-inline' is a stop-gap while I remove inline scripts and styles into local CSS and Script files.
