### PR TITLE
Ajax post absolute url

### DIFF
--- a/simplerisk/management/index.php
+++ b/simplerisk/management/index.php
@@ -815,7 +815,7 @@ $(document).ready(function() {
     $('#show-alert').html('');
     $.ajax({
       type: "POST",
-      url: "/management/index.php",
+      url: "index.php",
       data: form,
       async: false,
       cache: false,


### PR DESCRIPTION
We are unable to POST form with use of ajax when our path will be like:
xyz.com/foo/management/index.php
because the url was set to absolute path and would look for:
xyz.com/management/index.php

I have made a quick fix to make it working