### PR TITLE
Validate upload filesize is smaller than or equal to PHP limits

### DIFF
--- a/simplerisk/admin/uploads.php
+++ b/simplerisk/admin/uploads.php
@@ -106,6 +106,8 @@
 			set_alert(true, "bad", "The maximum upload file size needs to be an integer value.");
 		}
 	}
+    $simplerisk_max_upload_size = get_setting('max_upload_size');
+    $php_max_upload_size = min(convert_file_size_into_bytes(ini_get('upload_max_filesize')), convert_file_size_into_bytes(ini_get('post_max_size')));
 
 ?>
 
@@ -159,6 +161,9 @@
                 <p>
                 <h4><?php echo $escaper->escapeHtml($lang['MaximumUploadFileSize']); ?>:</h4>
                 <input name="size" type="number" maxlength="50" size="20" value="<?php echo get_setting('max_upload_size'); ?>" />&nbsp;<?php echo $escaper->escapeHtml($lang['Bytes']); ?><br />
+                <?php if($simplerisk_max_upload_size > $php_max_upload_size) {
+                    echo $escaper->escapeHtml($lang['WarnUploadSize']) . '<br />';
+                } ?>
                 <input type="submit" value="<?php echo $escaper->escapeHtml($lang['Update']); ?>" name="update_max_upload_size" />
                 </form>
               </div>

--- a/simplerisk/includes/functions.php
+++ b/simplerisk/includes/functions.php
@@ -10170,4 +10170,28 @@ function set_unauthenticated_redirect()
 	$_SESSION['requested_url'] = $requested_url;
 }
 
+/******************************************
+ * FUNCTION: CONVERT FILE SIZE INTO BYTES *
+ ******************************************/
+function convert_file_size_into_bytes($file_size)
+{
+    // Take a file size in the format ^\s*\d+\s*[kmg].* and extract the number and suffix
+    if(preg_match("/^\s*(\d+)\s*([kmg])/i", $file_size, $matches))
+    {
+        $value = (int) $matches[1];
+        $suffix = strtolower($matches[2]);
+        switch($suffix) {
+        case "g":
+            $value *= 1024;
+        case "m":
+            $value *= 1024;
+        case "k":
+            $value *= 1024;
+        }
+        return $value;
+    }
+    // return false to indicate parsing failed
+    return false;
+}
+
 ?>

--- a/simplerisk/languages/en/lang.en.php
+++ b/simplerisk/languages/en/lang.en.php
@@ -880,6 +880,7 @@ $lang = array(
     'AuditsDueSoon' => 'Audits Due Soon',
     'DateDue' => 'Date Due',
     'ShowAllRisksForPlanProjects' => 'Show all risks for planned projects instead of only those reviewed as "Consider for Project"',
+    'WarnUploadSize' => 'Warning: the current file size limit is larger than PHP allows to be uploaded. Check the upload_max_filesize and post_max_size configuration variables in your php.ini',
     '' => '',
 );
 


### PR DESCRIPTION
PHP uses two variables that control the size of files that can be uploaded in a POST request, `upload_max_filesize` and `post_max_size`. If these are smaller than the SimpleRisk filesize limit and a file is uploaded that is below the SimpleRisk limit but greater than either of the above, then SimpleRisk will display an error to the end-user about a failed CRSF check, but the Apache logs will correctly record that one of the limits was exceeded.

This change displays a warning to an admin user when they change the upload limit if it exceeds either of those PHP limits, so they know what they need to change.

TODO: do localisation for other languages other than en.