### PR TITLE
Display a single value for equal min and max value ranges.

### DIFF
--- a/simplerisk/includes/assets.php
+++ b/simplerisk/includes/assets.php
@@ -750,7 +750,16 @@ function create_asset_valuation_dropdown($name, $selected = NULL)
         }
         else $text = "";
 
-        echo "  <option value=\"" . $escaper->escapeHtml($value['id']) . "\"" . $text . ">" . $escaper->escapeHtml(get_setting("currency")) . $escaper->escapeHtml(number_format($value['min_value'])) . " to " . $escaper->escapeHtml(get_setting("currency")) . $escaper->escapeHtml(number_format($value['max_value'])) . "</option>\n";
+        echo "  <option value=\"" . $escaper->escapeHtml($value['id']) . "\"" . $text . ">";
+        if($value['min_value'] === $value['max_value'])
+        {
+            echo $escaper->escapeHtml(get_setting("currency")) . $escaper->escapeHtml(number_format($value['min_value']));
+        }
+        else
+        {
+            echo $escaper->escapeHtml(get_setting("currency")) . $escaper->escapeHtml(number_format($value['min_value'])) . " to " . $escaper->escapeHtml(get_setting("currency")) . $escaper->escapeHtml(number_format($value['max_value']));
+        }
+        echo "</option>\n";
     }
 
     echo "</select>\n";
@@ -894,7 +903,11 @@ function get_asset_value_by_id($id="")
     }
     
     if(!empty($value)){
-        $asset_value = get_setting("currency") . number_format($value['min_value']) . " to " . get_setting("currency") . number_format($value['max_value']);
+        if($value['min_value'] === $value['max_value']){
+            $asset_value = get_setting("currency") . number_format($value['min_value']);
+        }else{
+            $asset_value = get_setting("currency") . number_format($value['min_value']) . " to " . get_setting("currency") . number_format($value['max_value']);
+        }
     }else{
         $asset_value = "Undefined";
     }


### PR DESCRIPTION
If the minimum and maximum values are the same for a given value range, this commit only displays one of the values with a currency prefix (arbitrarily choosing the minimum, but it shouldn't matter either way since they are the same), rather than the normal 'min to max'.

Our particular use-case for this feature is when assets and mitigations have not been valued, then they are currently displayed as being in the lowest bracket automatically. To distinguish this from valued assets and mitigations, we have set the lowest bracket to a minimum and maximum value of 0 to denote this fact. However, this is being rendered as '$0 to $0', which is not desirable. An alternative solution would be to allow asset values and mitigation costs to be null.