### PR TITLE
Display enabled/disabled status when editing a user

### DIFF
--- a/simplerisk/admin/view_user_details.php
+++ b/simplerisk/admin/view_user_details.php
@@ -158,6 +158,7 @@
       // Get the users information
       $user_info = get_user_by_id($user_id);
       
+      $enabled = $user_info['enabled'];
       $lockout = $user_info['lockout'];
       $type = $user_info['type'];
       $username = $user_info['username'];
@@ -200,6 +201,7 @@
   else
   {
       $user_id = "";
+      $enabled = 0;
       $lockout = false;
       $type       = "N/A";
       $username   = "N/A";
@@ -443,6 +445,10 @@
                                         <td colspan="2">                                
                                             <input name="change_password" id="change_password" <?php if(isset($change_password) && $change_password == 1) echo "checked"; ?> class="hidden-checkbox" type="checkbox" value="1" />  <label for="change_password">  &nbsp;&nbsp;&nbsp; <?php echo $escaper->escapeHtml($lang['RequirePasswordChangeOnLogin']); ?> </label>
                                         </td>
+                                    </tr>
+                                    <tr>
+                                        <td><?php echo $escaper->escapeHtml($lang['Status']); ?>:&nbsp;</td>
+                                        <td><?php echo ($enabled == 1 ? $escaper->escapeHtml($lang['Enabled']) : '<b>' . $escaper->escapeHtml($lang['Disabled']) . '</b>'); ?></td>
                                     </tr>
                                     <tr>
                                         <td><?php echo $escaper->escapeHtml($lang['Type']); ?>:&nbsp;</td>

--- a/simplerisk/languages/en/lang.en.php
+++ b/simplerisk/languages/en/lang.en.php
@@ -950,6 +950,7 @@ $lang = array(
     'WarnPHPUploadSize' => 'Warning: the current file size limit is larger than PHP allows to be uploaded. Check the upload_max_filesize, post_max_size, and memory_limit values in your php.ini file.',
     'WarnMySQLUploadSize' => 'Warning: the current file size limit is larger than MySQL is configured for uploads.  Check the max_allowed_packet and innodb_log_file_size values in your my.ncf file.',
     'Restore' => 'Restore',
+    'Disabled' => 'Disabled',
     '' => '',
 );
 


### PR DESCRIPTION
When an administrator is editing a user, they cannot easily see whether that user is enabled or not, which can lead to confusion when debugging user access to the system. This commit adds a new row to the table to display this information.

It may also be desirable to make the enabled/disabled status toggle-able in this view, but I was not sure about the preferred interaction flow for such a change, so have not attempted to do so - but if you have any ideas about this, I would be happy to implement them as part of this PR.