### PR TITLE
Add README marking this repo as a release mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# SimpleRisk
+
+This repository contains the currently released source code of the
+[SimpleRisk](https://www.simplerisk.com) open-source risk management platform.
+
+> [!NOTE]
+> **This repository is a read-only publish mirror.** Each SimpleRisk release
+> lands here as a single "SimpleRisk \<version\> Release" commit, tagged with
+> the release version. Development does not happen in this repository, and
+> pull requests opened here cannot be merged — any change committed directly
+> would be overwritten by the next release sync.
+
+## Releases
+
+- Every release is an annotated tag (e.g. `20260519-001`) pointing at its
+  release commit, going back to 2014.
+- A tag tracks where its release version *currently* stands: in the rare case
+  a release is re-issued under the same version, the tag moves to the newer
+  commit.
+- Downloadable release bundles, hosted installers, and upgrade tooling are
+  available at [simplerisk.com/download](https://www.simplerisk.com/download).
+
+## Contributing and support
+
+SimpleRisk development happens in a private repository that is mirrored here
+at release time by the SimpleRisk team. To report a bug, request a feature,
+or contribute, please reach out through
+[support.simplerisk.com](https://support.simplerisk.com) rather than opening
+a pull request here.


### PR DESCRIPTION
## Description

Adds a README documenting that this repository is a read-only publish mirror of the SimpleRisk core:

- Each release arrives as a single tagged "SimpleRisk \<version\> Release" commit; tags track where a version currently stands (a re-issued version moves its tag).
- Direct commits and pull requests here can't land — branch protection restricts pushes to the release-sync App, and any direct change would be overwritten by the next sync.
- Points bug reports, feature requests, and contributions at support.simplerisk.com, and downloads at simplerisk.com/download.

Companion to the README added to simplerisk-extras; the equivalent sync workflow for this repo is simplerisk/code-development#1764.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
