### PR TITLE
Address propagation review findings from code-development#1764

### DIFF
--- a/.github/workflows/propagate_release_bundle.yml
+++ b/.github/workflows/propagate_release_bundle.yml
@@ -116,8 +116,12 @@ jobs:
           # Idempotency: compare git blob shas via the trees API (the
           # contents API errors on >1 MB files; tree listings are cheap).
           NEW_SHA=$(git hash-object "$FILE")
+          # An absent file yields empty jq output with exit 0; a non-zero
+          # exit is a REAL API failure (auth, rate limit, network) and must
+          # fail here, not several Git Data calls later with a cryptic error.
           EXISTING_SHA=$(gh api "repos/simplerisk/bundles/git/trees/master" \
-            --jq ".tree[] | select(.path==\"$FILE\") | .sha" || true)
+            --jq ".tree[] | select(.path==\"$FILE\") | .sha") \
+            || { echo "::error::failed to fetch bundles tree — cannot check idempotency"; exit 1; }
           if [ "$NEW_SHA" = "$EXISTING_SHA" ]; then
             echo "action=identical-skip" >> "$GITHUB_OUTPUT"
             exit 0
@@ -210,6 +214,12 @@ jobs:
           # then rewrite bundle_md5 and insert bundle_sha256 after it.
           sed -i "/<release version=\"$VERSION\">/,/<\/release>/{ /<bundle_sha256>/d }" releases.xml
           sed -i "/<release version=\"$VERSION\">/,/<\/release>/ s|<bundle_md5>[^<]*</bundle_md5>|<bundle_md5>$MD5</bundle_md5>\n        <bundle_sha256>$SHA256</bundle_sha256>|" releases.xml
+          # The substitution is a silent no-op if the entry has no
+          # <bundle_md5> (schema drift); fail loudly instead of committing
+          # an unchanged file and reporting success.
+          if ! grep -q "<bundle_sha256>$SHA256</bundle_sha256>" releases.xml; then
+            echo "::error::sed did not insert bundle_sha256 — releases.xml schema may have changed"; exit 1
+          fi
 
           base64 -w0 releases.xml > /tmp/releases.b64
           jq -n --rawfile content /tmp/releases.b64 \
@@ -226,6 +236,7 @@ jobs:
         env:
           VERSION: ${{ steps.ver.outputs.version }}
         run: |
+          set -euo pipefail
           {
             echo "## Propagated release bundle"
             echo


### PR DESCRIPTION
## Description

The automated deep review on simplerisk/code-development#1764 flagged three items in this workflow (it reviewed the plan-embedded template; the live file has the same code):

1. **(Important)** `|| true` on the bundles-tree idempotency lookup masked real API failures (auth, rate limit, network) — a transient error silently took the create path and failed several Git Data calls later with a cryptic error. Now fails immediately with a clear message. An absent file still works (empty jq output, exit 0).
2. **(Minor)** The releases.xml sed was a silent no-op if the version entry lacked `<bundle_md5>` (schema drift) — the workflow would commit an unchanged file and report success. Now verified with a grep before the PUT.
3. **(Minor)** The step-summary run block was the only one without `set -euo pipefail`.

No behavioral change on the happy path; re-run heal semantics unchanged. Companion parity update to the plan-embedded template: code-development (FEATURE-release-workflows-skill branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)