### PR TITLE
ci: source the CORE_SYNC App credentials from the release environment

### DIFF
--- a/.github/workflows/propagate_release_bundle.yml
+++ b/.github/workflows/propagate_release_bundle.yml
@@ -58,6 +58,11 @@ concurrency:
 
 jobs:
   propagate:
+    # The CORE_SYNC App credentials are environment secrets on `release`,
+    # whose deployment-branch policy pins it to master -- the ref both real
+    # triggers already use (repository_dispatch always runs on the default
+    # branch, and the workflow_dispatch heal reads a release asset from it).
+    environment: release
     runs-on: ubuntu-latest
     steps:
       - name: Resolve and validate version


### PR DESCRIPTION
Moves `CORE_SYNC_APP_ID` / `CORE_SYNC_APP_PRIVATE_KEY` from repo secrets to **environment** secrets on `release`, whose deployment-branch policy pins it to `master`.

That's the ref both real triggers already use:

- `repository_dispatch` always runs on the default branch
- the `workflow_dispatch` heal reads a release asset from `simplerisk/code`, so it's only meaningful from `master`

No behaviour change on the happy path.

### Ordering note for whoever merges
The `release` environment exists but holds no values yet — secret values can't be copied programmatically. Sequence:

1. Populate `CORE_SYNC_APP_ID` + `CORE_SYNC_APP_PRIVATE_KEY` on the `release` environment.
2. Merge this PR.
3. Remove the repo-level copies.

Doing 3 before 1 will fail the next release propagation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)